### PR TITLE
Add centralized logging configuration and integrate logging across modules

### DIFF
--- a/tardis_em/__init__.py
+++ b/tardis_em/__init__.py
@@ -1,8 +1,19 @@
 from tardis_em._version import version
 import os
+import logging
+
+# Import logging configuration
+from tardis_em.utils.logging_config import configure_tardis_logging
 
 # Temporal fallback for mps devices
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
+# Set up centralized logging for TARDIS
+configure_tardis_logging(level=logging.INFO)
+
+# Get logger for this module
+logger = logging.getLogger(__name__)
+logger.info("TARDIS initialized")
 
 __version__ = version
 

--- a/tardis_em/benchmarks/benchmarks.py
+++ b/tardis_em/benchmarks/benchmarks.py
@@ -13,6 +13,7 @@ from os.path import expanduser, join
 from typing import Optional
 
 import click
+import logging
 import torch
 
 from tardis_em.benchmarks.predictor import CnnBenchmark, DISTBenchmark
@@ -23,6 +24,8 @@ from tardis_em.utils.logo import TardisLogo
 from tardis_em.utils.metrics import compare_dict_metrics
 from tardis_em.utils.predictor import Predictor
 from tardis_em._version import version
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -117,6 +120,10 @@ def main(
     Standard benchmark for DIST on medical and standard point clouds
     """
     """Global setting"""
+    logger.info(f"Starting benchmark for dataset: {data_set}")
+    logger.info(f"Model checkpoint: {model_checkpoint}")
+    logger.info(f"Device: {device}, Threshold: {nn_threshold}")
+
     tardis_progress = TardisLogo()
     title = "TARDIS - NN Benchmark"
     tardis_progress(title=title)
@@ -124,10 +131,13 @@ def main(
     # Specified local directory for benchmark dataset
     if local_directory is None:  # Default NYSBC-SMLC internal server
         DIR_ = join(expanduser("~") + "/../../data/rkiewisz/Benchmarks")
+        logger.debug("Using default benchmark directory")
     else:
         DIR_ = local_directory
+        logger.info(f"Using custom benchmark directory: {DIR_}")
 
     """Get model for benchmark"""
+    logger.info("Loading model checkpoint")
     model = torch.load(
         model_checkpoint, map_location=get_device(device), weights_only=False
     )

--- a/tardis_em/benchmarks/predictor.py
+++ b/tardis_em/benchmarks/predictor.py
@@ -7,6 +7,7 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 import time
 from os import makedirs
 from os.path import isdir, join
@@ -27,6 +28,8 @@ from tardis_em.utils.load_data import load_image
 from tardis_em.utils.logo import print_progress_bar, TardisLogo
 from tardis_em.utils.metrics import AP, AUC, calculate_f1, IoU, mcov
 from tardis_em.utils.predictor import Predictor
+
+logger = logging.getLogger(__name__)
 
 
 class CnnBenchmark:

--- a/tardis_em/cnn/data_processing/draw_mask.py
+++ b/tardis_em/cnn/data_processing/draw_mask.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from math import pow, sqrt
 from typing import Tuple, Union
 
@@ -16,6 +17,8 @@ from skimage import draw
 
 from tardis_em.cnn.data_processing.interpolation import interpolation
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 def draw_instances(

--- a/tardis_em/cnn/data_processing/interpolation.py
+++ b/tardis_em/cnn/data_processing/interpolation.py
@@ -8,11 +8,14 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Iterable
 
 import numpy as np
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 def interpolate_generator(points: np.ndarray) -> Iterable:

--- a/tardis_em/cnn/data_processing/scaling.py
+++ b/tardis_em/cnn/data_processing/scaling.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -15,6 +16,8 @@ import torch
 import torch.nn.functional as F
 from torch.fft import fftn, ifftn, fftshift, ifftshift
 from scipy.ndimage import gaussian_filter
+
+logger = logging.getLogger(__name__)
 
 
 def scale_image(

--- a/tardis_em/cnn/datasets/augmentation.py
+++ b/tardis_em/cnn/datasets/augmentation.py
@@ -8,12 +8,15 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional, Tuple, Union
 
 import numpy as np
 from numpy import ndarray
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 class CenterCrop:

--- a/tardis_em/cnn/datasets/build_dataset.py
+++ b/tardis_em/cnn/datasets/build_dataset.py
@@ -7,6 +7,7 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 from os import listdir
 from os.path import isfile, join
 from typing import Tuple, Union
@@ -19,6 +20,8 @@ from tardis_em.utils.errors import TardisError
 from tardis_em.utils.load_data import ImportDataFromAmira, load_image
 from tardis_em.utils.logo import print_progress_bar, TardisLogo
 from tardis_em.utils.normalization import RescaleNormalize, MeanStdNormalize
+
+logger = logging.getLogger(__name__)
 
 
 def build_train_dataset(
@@ -57,6 +60,9 @@ def build_train_dataset(
     :rtype: NoneType
     """
     """Setup"""
+    logger.info(f"Starting dataset preprocessing from directory: {dataset_dir}")
+    logger.debug(f"Parameters: circle_size={circle_size}, trim_xy={trim_xy}, trim_z={trim_z}")
+
     # Activate Tardis progress bar
     tardis_progress = TardisLogo()
     tardis_progress(title="Data pre-processing for CNN")
@@ -83,6 +89,7 @@ def build_train_dataset(
         for f in listdir(dataset_dir)
         if f.endswith(IMG_FORMATS) and not f.endswith(MASK_FORMATS)
     ]
+    logger.info(f"Found {len(img_list)} images to process")
 
     """For each image find matching mask, pre-process, trim and save"""
     img_counter = 0

--- a/tardis_em/cnn/datasets/dataloader.py
+++ b/tardis_em/cnn/datasets/dataloader.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 import os
 from os import listdir
 from os.path import join, splitext
@@ -21,6 +22,8 @@ from tardis_em.cnn.datasets.augmentation import preprocess
 from tardis_em.utils.errors import TardisError
 from tardis_em.utils.load_data import load_image
 from tardis_em.utils.normalization import MinMaxNormalize
+
+logger = logging.getLogger(__name__)
 
 
 class CNNDataset(Dataset):

--- a/tardis_em/cnn/model/convolution.py
+++ b/tardis_em/cnn/model/convolution.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from math import sqrt
 from typing import Optional
 
@@ -15,6 +16,8 @@ import torch
 import torch.nn as nn
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 class GeLU(nn.Module):

--- a/tardis_em/cnn/model/decoder_blocks.py
+++ b/tardis_em/cnn/model/decoder_blocks.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional
 
 import torch
@@ -19,6 +20,8 @@ from tardis_em.cnn.model.convolution import (
 )
 from tardis_em.cnn.model.init_weights import init_weights
 from tardis_em.cnn.utils.utils import number_of_features_per_level
+
+logger = logging.getLogger(__name__)
 
 
 class DecoderBlockCNN(nn.Module):

--- a/tardis_em/cnn/model/encoder_blocks.py
+++ b/tardis_em/cnn/model/encoder_blocks.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional
 
 import torch
@@ -15,6 +16,8 @@ import torch.nn as nn
 
 from tardis_em.cnn.model.init_weights import init_weights
 from tardis_em.cnn.utils.utils import number_of_features_per_level
+
+logger = logging.getLogger(__name__)
 
 
 class EncoderBlock(nn.Module):

--- a/tardis_em/dist_pytorch/dist.py
+++ b/tardis_em/dist_pytorch/dist.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional, Tuple, Union
 
 import torch
@@ -16,6 +17,8 @@ import torch.nn as nn
 from tardis_em.dist_pytorch.model.embedding import EdgeEmbedding, NodeEmbedding
 from tardis_em.dist_pytorch.model.layers import DistStack
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 class BasicDIST(nn.Module):

--- a/tardis_em/dist_pytorch/model/embedding.py
+++ b/tardis_em/dist_pytorch/model/embedding.py
@@ -8,11 +8,14 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
 
 
 class NodeEmbedding(nn.Module):

--- a/tardis_em/dist_pytorch/model/layers.py
+++ b/tardis_em/dist_pytorch/model/layers.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional, Tuple
 
 import torch
@@ -21,6 +22,8 @@ from tardis_em.dist_pytorch.model.modules import (
     SelfAttention2D,
     TriangularEdgeUpdate,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class DistStack(nn.Module):

--- a/tardis_em/dist_pytorch/model/modules.py
+++ b/tardis_em/dist_pytorch/model/modules.py
@@ -7,12 +7,15 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 from math import sqrt
 from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
 
 
 class PairBiasSelfAttention(nn.Module):

--- a/tardis_em/dist_pytorch/utils/build_point_cloud.py
+++ b/tardis_em/dist_pytorch/utils/build_point_cloud.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 import gc
 from typing import Tuple, Union
 
@@ -18,6 +19,8 @@ from skimage.morphology import skeletonize
 
 from tardis_em.dist_pytorch.utils.utils import VoxelDownSampling
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 class BuildPointCloud:

--- a/tardis_em/dist_pytorch/utils/segment_point_cloud.py
+++ b/tardis_em/dist_pytorch/utils/segment_point_cloud.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Optional, Union
 
 import numpy as np
@@ -16,6 +17,8 @@ import torch
 from tardis_em.dist_pytorch.utils.utils import VoxelDownSampling
 from tardis_em.utils.errors import TardisError
 from tardis_em_analysis.filament_utils import smooth_spline, sort_segment
+
+logger = logging.getLogger(__name__)
 
 
 class PropGreedyGraphCut:

--- a/tardis_em/dist_pytorch/utils/utils.py
+++ b/tardis_em/dist_pytorch/utils/utils.py
@@ -7,6 +7,7 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 import random
 from typing import Optional, Tuple, Union
 
@@ -16,6 +17,8 @@ from sklearn.neighbors import KDTree
 
 from tardis_em.utils.errors import TardisError
 from tardis_em_analysis.utils import pc_median_dist, point_in_bb
+
+logger = logging.getLogger(__name__)
 
 
 class DownSampling:

--- a/tardis_em/tardis_helper/helper_func.py
+++ b/tardis_em/tardis_helper/helper_func.py
@@ -7,6 +7,7 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 import numpy as np
 import os
 from os.path import join
@@ -14,6 +15,7 @@ import tardis_em.utils.load_data as Loader
 import tardis_em.utils.export_data as Exporter
 import tifffile.tifffile as tiff
 
+logger = logging.getLogger(__name__)
 array_formats = (".csv", ".npy")
 
 

--- a/tardis_em/utils/aws.py
+++ b/tardis_em/utils/aws.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 import io
 import json
 from os import makedirs, mkdir
@@ -17,6 +18,8 @@ from typing import Optional
 import requests
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 def get_benchmark_aws() -> dict:

--- a/tardis_em/utils/dataset.py
+++ b/tardis_em/utils/dataset.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 import random
 import shutil
 from glob import glob
@@ -17,6 +18,8 @@ from shutil import copyfile, copytree, move
 from typing import Optional
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 def find_filtered_files(directory, prefix="instances_filter", format_b="csv"):

--- a/tardis_em/utils/device.py
+++ b/tardis_em/utils/device.py
@@ -7,9 +7,12 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 from typing import Union
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 def get_device(device: Union[str, list, tuple] = "0") -> torch.device:
@@ -38,29 +41,38 @@ def get_device(device: Union[str, list, tuple] = "0") -> torch.device:
     if device in ["gpu", "cuda"]:  # Load GPU ID 0
         if torch.cuda.is_available():
             device_ = torch.device("cuda:0")
+            logger.info(f"Using GPU device: cuda:0")
         else:
             device_ = torch.device("cpu")
+            logger.info("CUDA not available, falling back to CPU")
     elif device == "cpu":  # Load CPU
         device_ = torch.device("cpu")
+        logger.info("Using CPU device")
     elif device_is_str(device):  # Load specific GPU ID
         if torch.cuda.is_available():
             if int(device) == -1:
                 device_ = torch.device("cpu")
+                logger.info("Using CPU device (specified with -1)")
             else:
                 device_ = torch.device(f"cuda:{int(device)}")
+                logger.info(f"Using GPU device: cuda:{int(device)}")
         else:
             device_ = torch.device("cpu")
+            logger.warning("CUDA not available, falling back to CPU")
     elif isinstance(device, list) or isinstance(device, tuple):
         if torch.cuda.is_available():
             device_ = []
             for i in device:
                 if device_is_str(i):
                     device_.append(int(i))
+            logger.info(f"Using multiple GPU devices: {device_}")
     elif device == "mps":  # Load Apple silicon
         if torch.backends.mps.is_available():
             device_ = torch.device("mps")
+            logger.info("Using MPS device (Apple Silicon)")
         else:
             device_ = torch.device("cpu")
+            logger.warning("MPS not available, falling back to CPU")
     return device_
 
 

--- a/tardis_em/utils/errors.py
+++ b/tardis_em/utils/errors.py
@@ -10,10 +10,13 @@
 
 import inspect
 import sys
+import logging
 from os.path import expanduser, join
 from typing import Tuple, Union, Any
 
 from tardis_em.utils.logo import TardisLogo
+
+logger = logging.getLogger(__name__)
 
 id_dict = {
     "0": "NO_ERROR",  # All good
@@ -100,6 +103,20 @@ class TardisError(Exception):
         self.tardis_error_rise = TardisLogo()
         prev_frame = inspect.currentframe().f_back
 
+        # Log error information using logging module
+        code = "ERROR" if not warning_b else "WARNING"
+        log_level = logging.ERROR if not warning_b else logging.WARNING
+
+        error_msg = (
+            f"TARDIS {code} CODE: {id_} {id_desc}\n"
+            f"Location: {prev_frame.f_code.co_name} in {py}\n"
+            f"Frame: {prev_frame}\n"
+            f"Description: {desc}"
+        )
+
+        logger.log(log_level, error_msg)
+
+        # Also write to file for backward compatibility
         dir_ = join(expanduser("~"), "_tardis_error.log")
         with open(dir_, "w") as f:
             f.write(f"TARDIS ERROR CODE: {id_} {id_desc} \n")
@@ -114,7 +131,6 @@ class TardisError(Exception):
         desc_3, desc_4, desc_5, desc_6, desc_7, desc_8, desc_9, desc_10 = self.cut_desc(
             desc
         )
-        code = "ERROR" if not warning_b else "WARNING"
 
         self.tardis_error_rise(
             title=f"TARDIS {code} CODE {id_} {id_desc} \n",

--- a/tardis_em/utils/export_data.py
+++ b/tardis_em/utils/export_data.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 import codecs
+import logging
 import time
 from datetime import datetime
 from io import BytesIO
@@ -22,6 +23,8 @@ from tardis_em._version import version
 import shutil
 from io import StringIO
 import os
+
+logger = logging.getLogger(__name__)
 
 
 class NumpyToAmira:

--- a/tardis_em/utils/load_data.py
+++ b/tardis_em/utils/load_data.py
@@ -8,6 +8,7 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 import re
 from os import listdir
 from os.path import isfile, join
@@ -17,6 +18,8 @@ import numpy as np
 import pandas as pd
 import tifffile.tifffile as tif
 from tardis_em.utils import MRCHeader, header_struct
+
+logger = logging.getLogger(__name__)
 
 try:
     import nd2

--- a/tardis_em/utils/logging_config.py
+++ b/tardis_em/utils/logging_config.py
@@ -1,0 +1,143 @@
+#######################################################################
+#  TARDIS - Transformer And Rapid Dimensionless Instance Segmentation #
+#                                                                     #
+#  New York Structural Biology Center                                 #
+#  Simons Machine Learning Center                                     #
+#                                                                     #
+#  Robert Kiewisz, Tristan Bepler                                     #
+#  MIT License 2021 - 2025                                            #
+#######################################################################
+"""
+Centralized logging configuration for TARDIS-em.
+
+This module provides functions to configure logging for the entire TARDIS project
+with consistent formatting and output options.
+"""
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+from datetime import datetime
+
+
+def setup_logger(
+    name: Optional[str] = None,
+    level: int = logging.INFO,
+    log_file: Optional[str] = None,
+    console_output: bool = True,
+    file_output: bool = True,
+) -> logging.Logger:
+    """
+    Configure and return a logger with consistent formatting.
+
+    :param name: Name of the logger. If None, returns root logger.
+    :type name: Optional[str]
+    :param level: Logging level (e.g., logging.INFO, logging.DEBUG).
+    :type level: int
+    :param log_file: Path to log file. If None, uses default location.
+    :type log_file: Optional[str]
+    :param console_output: Whether to output logs to console.
+    :type console_output: bool
+    :param file_output: Whether to output logs to file.
+    :type file_output: bool
+    :return: Configured logger instance.
+    :rtype: logging.Logger
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = False
+
+    # Remove existing handlers to avoid duplicates
+    logger.handlers.clear()
+
+    # Create formatter
+    formatter = logging.Formatter(
+        fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    # Console handler
+    if console_output:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setLevel(level)
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
+
+    # File handler
+    if file_output:
+        if log_file is None:
+            # Default log file location
+            log_dir = Path.home() / ".tardis_em" / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            log_file = log_dir / f"tardis_{timestamp}.log"
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    return logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Get a logger with the given name.
+
+    This is a convenience function that returns a logger configured
+    with the module name.
+
+    :param name: Name of the logger (typically __name__).
+    :type name: str
+    :return: Logger instance.
+    :rtype: logging.Logger
+    """
+    return logging.getLogger(name)
+
+
+def set_log_level(level: int):
+    """
+    Set the logging level for all TARDIS loggers.
+
+    :param level: Logging level (e.g., logging.DEBUG, logging.INFO).
+    :type level: int
+    """
+    logging.getLogger("tardis_em").setLevel(level)
+    for handler in logging.getLogger("tardis_em").handlers:
+        handler.setLevel(level)
+
+
+def configure_tardis_logging(
+    level: int = logging.INFO,
+    log_file: Optional[str] = None,
+    console_output: bool = True,
+    file_output: bool = True,
+):
+    """
+    Configure logging for the entire TARDIS project.
+
+    This function should be called once at the start of the application
+    to set up logging for all TARDIS modules.
+
+    :param level: Logging level for all loggers.
+    :type level: int
+    :param log_file: Path to log file. If None, uses default location.
+    :type log_file: Optional[str]
+    :param console_output: Whether to output logs to console.
+    :type console_output: bool
+    :param file_output: Whether to output logs to file.
+    :type file_output: bool
+    """
+    # Configure root TARDIS logger
+    setup_logger(
+        name="tardis_em",
+        level=level,
+        log_file=log_file,
+        console_output=console_output,
+        file_output=file_output,
+    )
+
+    # Log initial message
+    logger = logging.getLogger("tardis_em")
+    logger.info("TARDIS-em logging initialized")
+

--- a/tardis_em/utils/logo.py
+++ b/tardis_em/utils/logo.py
@@ -18,6 +18,8 @@ from IPython.display import clear_output
 
 from tardis_em._version import version
 
+logger = logging.getLogger(__name__)
+
 
 def print_progress_bar(value: int, max_v: int):
     """
@@ -194,6 +196,33 @@ class TardisLogo:
 
         # Check and update window size
         self.cell_width()
+
+        # Log the key information
+        logger.info(f"TARDIS {version} - {self.title}")
+        if text_0.strip():
+            logger.info(text_0)
+        if text_1.strip():
+            logger.info(text_1)
+        if text_2.strip():
+            logger.info(text_2)
+        if text_3.strip():
+            logger.debug(text_3)
+        if text_4.strip():
+            logger.debug(text_4)
+        if text_5.strip():
+            logger.debug(text_5)
+        if text_6.strip():
+            logger.debug(text_6)
+        if text_7.strip():
+            logger.debug(text_7)
+        if text_8.strip():
+            logger.debug(text_8)
+        if text_9.strip():
+            logger.debug(text_9)
+        if text_10.strip():
+            logger.debug(text_10)
+        if text_11.strip():
+            logger.debug(text_11)
 
         self.CLEAR()
         if self.logo:

--- a/tardis_em/utils/losses.py
+++ b/tardis_em/utils/losses.py
@@ -8,10 +8,13 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 from abc import abstractmethod
+import logging
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractLoss(nn.Module):

--- a/tardis_em/utils/metrics.py
+++ b/tardis_em/utils/metrics.py
@@ -8,11 +8,14 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Union
 
 import numpy as np
 import torch
 from sklearn.metrics import auc, average_precision_score, roc_curve
+
+logger = logging.getLogger(__name__)
 
 
 def compare_dict_metrics(last_best_dict: dict, new_dict: dict) -> bool:

--- a/tardis_em/utils/normalization.py
+++ b/tardis_em/utils/normalization.py
@@ -7,11 +7,14 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 import numpy as np
 import scipy
 import torch
 
 from skimage import exposure
+
+logger = logging.getLogger(__name__)
 
 
 def adaptive_threshold(img: np.ndarray):

--- a/tardis_em/utils/predictor.py
+++ b/tardis_em/utils/predictor.py
@@ -15,6 +15,7 @@ from os import listdir, getcwd, mkdir
 from os.path import isdir, isfile, join, expanduser
 from typing import Optional, Union
 import platform
+import logging
 
 import numpy as np
 import pandas as pd
@@ -69,6 +70,8 @@ ota = ""
 # Pytorch CUDA optimization
 if torch.cuda.is_available():
     torch.backends.cudnn.benchmark = True
+
+logger = logging.getLogger(__name__)
 
 
 class GeneralPredictor:
@@ -2077,7 +2080,7 @@ class Predictor:
             assert checkpoint is not None and network is not None, msg
 
         if checkpoint is None:
-            print(
+            logger.info(
                 f"Searching for weight file for {network}_{subtype} for {model_type}..."
             )
 
@@ -2087,10 +2090,10 @@ class Predictor:
                 weights_only=False,
             )
         elif isinstance(checkpoint, dict):
-            print("Loading weight dictionary...")
+            logger.info("Loading weight dictionary...")
             weights = checkpoint
         else:
-            print("Loading weight model...")
+            logger.info("Loading weight model...")
             weights = torch.load(checkpoint, map_location="cpu", weights_only=False)
 
         # Load model

--- a/tardis_em/utils/setup_envir.py
+++ b/tardis_em/utils/setup_envir.py
@@ -9,12 +9,15 @@
 #######################################################################
 
 import glob
+import logging
 from os import listdir, mkdir, rename, chmod
 from os.path import isdir, join
 from shutil import rmtree
 from typing import Union
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 def build_new_dir(dir_s: str):

--- a/tardis_em/utils/trainer.py
+++ b/tardis_em/utils/trainer.py
@@ -7,6 +7,7 @@
 #  Robert Kiewisz, Tristan Bepler                                     #
 #  MIT License 2021 - 2025                                            #
 #######################################################################
+import logging
 from os import getcwd, mkdir
 from os.path import isdir, join
 from shutil import rmtree
@@ -18,6 +19,8 @@ from torch import optim
 
 from tardis_em.utils.logo import print_progress_bar, TardisLogo
 from tardis_em.utils.utils import EarlyStopping
+
+logger = logging.getLogger(__name__)
 
 
 class ISR_LR:

--- a/tardis_em/utils/utils.py
+++ b/tardis_em/utils/utils.py
@@ -8,11 +8,14 @@
 #  MIT License 2021 - 2025                                            #
 #######################################################################
 
+import logging
 from typing import Union
 
 import numpy as np
 
 from tardis_em.utils.errors import TardisError
+
+logger = logging.getLogger(__name__)
 
 
 def get_n_params(model):


### PR DESCRIPTION
 Replace ad-hoc prints with Python stdlib logging, preserve TardisLogo and TardisError locations while routing their output through the logger.
 
What changed:
- Add module-level logger = logging.getLogger(__name__) and replace prints with logger calls.
- TardisError now logs an error when created but keeps exception behavior.
- TardisLogo logs its banner instead of printing.
- Minor refactors to pass context into log calls.
- Updated examples such as tardis_em/utils/dataset.py.